### PR TITLE
Bump minimum version of Test::Script to 1.29

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -17,3 +17,6 @@ badges = github_tag
 badges = license
 place = top
 phase = build
+
+[Prereqs / TestRequires]
+Test::Script = 1.29

--- a/t/perlvars.t
+++ b/t/perlvars.t
@@ -4,10 +4,10 @@ use strict;
 use warnings;
 
 use Test::More import => [qw( done_testing subtest )];
-use Test::Script 1.27 qw(
+use Test::Script qw(
     script_compiles
+    script_fails
     script_runs
-    script_stderr_is
     script_stderr_like
 );
 


### PR DESCRIPTION
Fixes #1
